### PR TITLE
Fixing: C class 'SOL' is declared but not defined

### DIFF
--- a/python/pysol.pxd
+++ b/python/pysol.pxd
@@ -25,3 +25,10 @@ cdef extern from "sol/c_api.h":
     int sol_convert_data(const char* src_path, const char* src_type, const char* dst_path, const char* dst_type, bint binarize, float binarize_thresh)
     int sol_shuffle_data(const char* src_path, const char* src_type, const char* dst_path, const char* dst_type)
     int sol_split_data(const char* src_path, const char* src_type, int fold, const char* output_prefix, const char* dst_type, bint shuffle)
+
+cdef class SOL:
+    cdef void* _c_model
+    cdef void* _c_data_iter
+    cdef const char* algo
+    cdef int class_num
+    cdef bint verbose

--- a/python/pysol.pyx
+++ b/python/pysol.pyx
@@ -43,11 +43,6 @@ cdef void inspect_iteration(void* user_context,
         handler(data_num, iter_num, update_num, err_rate)
 
 cdef class SOL:
-    cdef void* _c_model
-    cdef void* _c_data_iter
-    cdef const char* algo
-    cdef int class_num
-    cdef bint verbose
 
     def  __cinit__(self, const char* algo = NULL, int class_num = -1, int
             batch_size=256, int buf_size = 2, verbose=False, **params):


### PR DESCRIPTION
After a clean python2.7 install (anaconda), python setup.py build
was returning this error. The solution was to simply move the
attribute declarations from the .pyx file into the .pxd.

Reference: https://stackoverflow.com/questions/17735051/share-extension-types-in-cython-for-static-typing?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa